### PR TITLE
Fix error folding long header attribute

### DIFF
--- a/mimetic/rfc822/field.cxx
+++ b/mimetic/rfc822/field.cxx
@@ -174,7 +174,7 @@ ostream& Field::write(ostream& os, unsigned int fold) const
                 if(!in_quote && isblank(ostr[i]))
                     sp = i; // last blank found
 
-                if(i >= static_cast<int>(fold && sp))
+                if(fold && sp && (i > 0))
                 {
                     os.write(ostr.c_str(), sp);
                     ostr.erase(0, 1+sp);


### PR DESCRIPTION
When sending a file with large filename, the block of code which is in charge of folding the attribute (because larger than 76), is removing the first 'C' letter. This PR fixes the wrong behaviour.